### PR TITLE
Add plublish maven when gradle version is greater or equal than 7.0

### DIFF
--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -60,12 +60,21 @@ plugins.withId('maven') {
                     }
                 }
 
-                // Sign the POM when the signing plugin is present
+                // Sign the POM when the signing plugin is present.
+                // If Gradle version < 7.0
                 plugins.withId('signing') {
                     if (project.hasProperty('doSigning')) {
                         beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
                     }
                 }
+
+                // Sign the POM when the signing plugin is present.
+                // If Gradle version > 7.0
+                //if (project.hasProperty('doSigning')) {
+                //    plugins {
+                //        id 'signing'
+                //    }
+                //}
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: davideduma <david24eduma@gmail.com>

Tags:
@JhoanAlvear
@davideduma

**Change log description**  
MavenDeployment deployment is deprecated.
Update come from:  https://docs.gradle.org/current/userguide/publishing_maven.html

![image](https://user-images.githubusercontent.com/86481341/209859246-f8d4d257-7fd3-4655-8944-95a140f9ff2d.png)


**Purpose of the change**  
ISSUE:  https://github.com/pravega/pravega/issues/6981

**What the code does**  
Reemplace el código antiguo para actualizar el script. Sugerir documentos gradle.
 https://docs.gradle.org/current/userguide/publishing_maven.html

**How to verify it**  
Description about how to verify on the link below : https://github.com/pravega/pravega/issues/6981
